### PR TITLE
Add CI workflow for multi-version testing

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -1,0 +1,34 @@
+name: Test Suite
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['2.7', '3.5', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [[ "$PYTHON_VERSION" == 3.12* ]]; then
+            python -m pip install nose-py3
+          else
+            python -m pip install nose
+          fi
+          python -m pip install numpy pandas scipy matplotlib ggplot statsmodels
+          python -m pip install .
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
+      - name: Run tests
+        run: |
+          python -m nose -s tests


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run the test suite on Python 2.7, 3.5, and 3.12
- install `nose-py3` on Python 3.12 and `nose` on earlier versions
- install required dependencies via pip before running nose

## Testing
- `pytest -q tests` *(fails: ImportError: cannot import name 'trapz' from 'scipy.integrate')*

------
https://chatgpt.com/codex/tasks/task_e_6882c90775a4832c932dfc1bedf481a4