### PR TITLE
Add semantic-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: |
+      !startsWith(github.event.head_commit.message, 'chore(release)')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Poetry
+        run: |
+          python -m pip install --upgrade pip
+          curl -sSL https://install.python-poetry.org | python - --yes
+          echo "PATH=$HOME/.local/bin:$PATH" >> $GITHUB_ENV
+      - name: Install dependencies
+        run: |
+          poetry install --no-interaction --no-root
+          poetry run pip install python-semantic-release
+      - name: Configure git
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+      - name: Release
+        env:
+          POETRY_VIRTUALENVS_CREATE: "false"
+        run: |
+          poetry run semantic-release publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,11 @@ nose = "*"
 [build-system]
 requires = ["poetry-core>=1.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.semantic_release]
+version_variable = "pyproject.toml:tool.poetry.version"
+branch = "main"
+changelog_file = "CHANGELOG.md"
+tag_format = "v{version}"
+upload_to_pypi = false
+commit_author = "github-actions <github-actions@github.com>"


### PR DESCRIPTION
## Summary
- integrate python-semantic-release configuration in `pyproject.toml`
- add a Release GitHub Actions workflow to automate versioning and changelog generation
- create an empty `CHANGELOG.md` file for releases

## Testing
- `python -m nose -s tests`

------
https://chatgpt.com/codex/tasks/task_e_6882dd9567bc832c8e448a180618a25d