### PR TITLE
Replace prints with logging

### DIFF
--- a/clintrials/__init__.py
+++ b/clintrials/__init__.py
@@ -12,3 +12,8 @@ __all__ = [
     "tte",
     "util",
 ]
+
+import logging
+
+# Attach a NullHandler to avoid logging warnings on import
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/clintrials/dosefinding/__init__.py
+++ b/clintrials/dosefinding/__init__.py
@@ -22,6 +22,8 @@ from clintrials.util import (
     to_1d_list,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class DoseFindingTrial(metaclass=abc.ABCMeta):
     """This is the base class for a dose-finding trial.
@@ -659,14 +661,14 @@ def find_mtd(toxicity_target, scenario, strictly_lte=False, verbose=False):
         # Return exact match
         loc = scenario.index(toxicity_target) + 1
         if verbose:
-            print("MTD is %s" % loc)
+            logger.info("MTD is %s", loc)
         return loc
     else:
         if strictly_lte:
             if sum(np.array(scenario) <= toxicity_target) == 0:
                 # Infeasible scenario
                 if verbose:
-                    print("All doses are too toxic")
+                    logger.warning("All doses are too toxic")
                 return 0
             else:
                 # Return highest tox no greater than target
@@ -677,13 +679,13 @@ def find_mtd(toxicity_target, scenario, strictly_lte=False, verbose=False):
                 )
                 loc = np.argmin(objective) + 1
                 if verbose:
-                    print("Highest dose below MTD is %s" % loc)
+                    logger.info("Highest dose below MTD is %s", loc)
                 return loc
         else:
             # Return nearest
             loc = np.argmin(np.abs(np.array(scenario) - toxicity_target)) + 1
             if verbose:
-                print("Dose nearest to MTD is %s" % loc)
+                logger.info("Dose nearest to MTD is %s", loc)
             return loc
 
 
@@ -775,27 +777,27 @@ def batch_summarise_dose_finding_sims(
         param_combinations = list(product(*val_arrays))
         for param_combo in param_combinations:
             for lab, vals in zip(labels, param_combo):
-                print(f"{lab}: {vals}")
+                logger.info("%s: %s", lab, vals)
             these_params = dict(zip(labels, param_combo))
             abc = summarise_dose_finding_sims(
                 sims, label, num_doses, filter=these_params
             )
             if func1:
-                print(func1(abc[0], these_params))
-                print("\n")
-                print("\n")
+                logger.info(func1(abc[0], these_params))
+                logger.info("")
+                logger.info("")
             else:
-                print("\n")
-                print(abc[0])
-                print("\n")
-                print(abc[1])
-                print("\n")
+                logger.info("")
+                logger.info(abc[0])
+                logger.info("")
+                logger.info(abc[1])
+                logger.info("")
     else:
         abc = summarise_dose_finding_sims(sims, label, num_doses)
-        print(abc[0])
-        print("\n")
-        print(abc[1])
-        print("\n")
+        logger.info(abc[0])
+        logger.info("")
+        logger.info(abc[1])
+        logger.info("")
 
 
 def dose_transition_pathways_to_json(
@@ -851,7 +853,7 @@ def dose_transition_pathways_to_json(
             )
             cases = cases_already_observed + cohort_cases
             if verbose:
-                print("Running %s" % cases)
+                logger.debug("Running %s", cases)
             trial.reset()
             # print 'next_dose is', trial.next_dose()
             trial.set_next_dose(next_dose)
@@ -915,7 +917,7 @@ def print_dtps(dtps, indent=0, dose_label_func=None):
         mtd = x["RecommendedDose"]
 
         template_txt = "\t" * indent + "{} -> Dose {}"
-        print(template_txt.format(num_tox, dose_label_func(mtd)))
+        logger.info(template_txt.format(num_tox, dose_label_func(mtd)))
 
         if "Next" in x:
             print_dtps(x["Next"], indent=indent + 1, dose_label_func=dose_label_func)

--- a/clintrials/dosefinding/efficacytoxicity.py
+++ b/clintrials/dosefinding/efficacytoxicity.py
@@ -18,6 +18,9 @@ from clintrials.util import (
 # from clintrials.simulation import filter_sims
 
 
+logger = logging.getLogger(__name__)
+
+
 # Joint Phase I/II, Assessing efficacy and toxicity
 class EfficacyToxicityDoseFindingTrial(metaclass=abc.ABCMeta):
     """This is the base class for a dose-finding trial that jointly monitors toxicity and efficacy.
@@ -612,7 +615,7 @@ def dose_transition_pathways(
             cohort_cases = [(next_dose, x[0], x[1]) for x in path]
             cases = cases_already_observed + cohort_cases
             if verbose:
-                print("Running %s" % cases)
+                logger.debug("Running %s", cases)
             trial.reset()
             obd = trial.update(cases, **kwargs)
             # Collect output
@@ -682,7 +685,9 @@ def print_dtps(dtps, indent=0, dose_label_func=None):
             template_txt = "\t" * indent + "{} -> Dose {}, Superiority={} * tentative *"
         else:
             template_txt = "\t" * indent + "{} -> Dose {}, Superiority={}"
-        print(template_txt.format(path, dose_label_func(obd), np.round(prob_sup, 2)))
+        logger.info(
+            template_txt.format(path, dose_label_func(obd), np.round(prob_sup, 2))
+        )
 
         if "Next" in x:
             print_dtps(x["Next"], indent=indent + 1, dose_label_func=dose_label_func)
@@ -712,7 +717,7 @@ def print_dtps_verbose(dtps, indent=0, dose_label_func=None):
             "\t" * indent
             + "{} -> Dose {}, Sup={}, Util={}, Pr(Acc Eff)={}, Pr(Acc Tox)={}"
         )
-        print(
+        logger.info(
             template_txt.format(
                 path,
                 dose_label_func(obd),

--- a/clintrials/logging.py
+++ b/clintrials/logging.py
@@ -1,0 +1,5 @@
+import logging
+
+
+def get_logger(name: str = __name__) -> logging.Logger:
+    return logging.getLogger(name)

--- a/clintrials/simulation.py
+++ b/clintrials/simulation.py
@@ -5,8 +5,11 @@ __contact__ = "kristian.brock@gmail.com"
 import glob
 import itertools
 import json
+import logging
 from collections import OrderedDict
 from datetime import datetime
+
+logger = logging.getLogger(__name__)
 
 
 def run_sims(sim_func, n1=1, n2=1, out_file=None, **kwargs):
@@ -40,8 +43,8 @@ def run_sims(sim_func, n1=1, n2=1, out_file=None, **kwargs):
                 with open(out_file, "w") as outfile:
                     json.dump(sims, outfile)
             except Exception as e:
-                print("Error writing: %s" % e)
-        print(f"{j} {datetime.now()} {len(sims)}")
+                logger.error("Error writing: %s", e)
+        logger.info(f"{j} {datetime.now()} {len(sims)}")
     return sims
 
 
@@ -80,8 +83,8 @@ def sim_parameter_space(sim_func, ps, n1=1, n2=None, out_file=None):
                 with open(out_file, "w") as outfile:
                     json.dump(sims, outfile)
             except Exception as e:
-                print("Error writing: %s" % e)
-        print(f"{j} {datetime.now()} {len(sims)}")
+                logger.error("Error writing: %s", e)
+        logger.info(f"{j} {datetime.now()} {len(sims)}")
     return sims
 
 
@@ -100,9 +103,9 @@ def go_fetch_json_sims(file_pattern):
     sims = []
     for f in files:
         sub_sims = _open_json_local(f)
-        print(f"{f} {len(sub_sims)}")
+        logger.info("%s %s", f, len(sub_sims))
         sims += sub_sims
-    print("Fetched %s sims" % len(sims))
+    logger.info("Fetched %s sims", len(sims))
     return sims
 
 
@@ -297,7 +300,7 @@ def fetch_partition_and_aggregate(f, ps, function_map, verbose=False):
 
     sims = _open_json_local(f)
     if verbose:
-        print(f"Fetched {len(sims)} sims from {f}")
+        logger.info("Fetched %s sims from %s", len(sims), f)
     return partition_and_aggregate(sims, ps, function_map)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ line_length = 88
 line-length = 88
 target-version = "py39"
 select = ["E", "F"]
+extend-select = ["T201"]
 ignore = [
     "E203",
     "E402",

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,20 @@
+import logging
+
+from clintrials.dosefinding import find_mtd
+from clintrials.simulation import run_sims
+
+
+def dummy_sim():
+    return {"ok": True}
+
+
+def test_find_mtd_logs(caplog):
+    with caplog.at_level(logging.INFO):
+        find_mtd(0.25, [0.15, 0.25, 0.35], verbose=True)
+    assert any("MTD is" in record.message for record in caplog.records)
+
+
+def test_run_sims_logs(caplog):
+    with caplog.at_level(logging.INFO):
+        run_sims(dummy_sim, n1=1, n2=1)
+    assert any(record.levelno == logging.INFO for record in caplog.records)


### PR DESCRIPTION
## Summary
- attach NullHandler to package logger and add helper
- replace print statements with logging calls
- prevent print statements via ruff T201
- add logging tests

## Testing
- `pre-commit run --files clintrials/__init__.py clintrials/logging.py clintrials/dosefinding/__init__.py clintrials/dosefinding/efficacytoxicity.py clintrials/phase2/bebop/peps2v1.py clintrials/simulation.py tests/test_logging.py pyproject.toml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882f4077524832cad5d3cf76dfd7d88