### PR TITLE
Fix lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,5 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .[dev]
+      - name: Install pre-commit
+        run: pip install pre-commit
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
## Summary
- install pre-commit in the lint workflow to avoid missing command errors

## Testing
- `pre-commit run --files .github/workflows/lint.yml`
- `pytest -q` *(fails: `test_efftox.py::test_thall2014_efftox_v2` and `test_watu.py`)*


------
https://chatgpt.com/codex/tasks/task_e_6883a04782f4832ca21256d8bcd388a5