### PR TITLE
Update Python version for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.9'
       - name: Install Poetry
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- use Python 3.9 in the release workflow so pre-commit installs correctly

## Testing
- `pytest -q` *(fails: test_watu_1, test_watu_2)*

------
https://chatgpt.com/codex/tasks/task_e_6883a09d25f0832c8bab9cb0b429a47c