### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fderuiter/clintrials/security/code-scanning/2](https://github.com/fderuiter/clintrials/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow. Since the workflow only performs linting and does not need to write to the repository, we will set `contents: read`. This ensures the workflow has read-only access to the repository contents, which is sufficient for its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
