### PR TITLE
Update docs workflow to Jekyll

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: docs
+name: Deploy Jekyll documentation
 
 on:
   pull_request:
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
@@ -42,8 +44,6 @@ jobs:
           sphinx-build -b html -n -W docs docs/_build/html
       - name: Linkcheck
         run: sphinx-build -b linkcheck docs docs/_build/linkcheck
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:

--- a/README.md
+++ b/README.md
@@ -125,3 +125,7 @@ Install the optional docs dependencies and run Sphinx:
 pip install -e .[docs]
 make -C docs html
 ```
+
+Documentation changes pushed to `main` are automatically deployed to
+GitHub Pages using a Jekyll workflow defined in
+`.github/workflows/docs.yml`.


### PR DESCRIPTION
## Summary
- update docs workflow to combine with sample Jekyll deployment
- note that docs site is deployed via GitHub Pages in README

## Testing
- `pytest -q` *(fails: test_watu)*

------
https://chatgpt.com/codex/tasks/task_e_6883a43eb6c0832cbd110432c19ff0ff