### PR TITLE
Fix formatting issues with black and isort

### DIFF
--- a/clintrials/dosefinding/crm/design.py
+++ b/clintrials/dosefinding/crm/design.py
@@ -9,8 +9,8 @@ import numpy as np
 from numpy import trapz
 from scipy.integrate import quad
 from scipy.optimize import minimize
-from scipy.stats import norm
 from scipy.special import logsumexp
+from scipy.stats import norm
 
 from clintrials.common import empiric, inverse_empiric, inverse_logistic, logistic
 from clintrials.dosefinding import DoseFindingTrial

--- a/clintrials/dosefinding/efftox.py
+++ b/clintrials/dosefinding/efftox.py
@@ -2,8 +2,8 @@ import warnings
 
 from .efftox.design import (
     EffTox,
-    LpNormCurve,
     InverseQuadraticCurve,
+    LpNormCurve,
     efftox_dtp_detail,
     solve_metrizable_efftox_scenario,
 )

--- a/clintrials/dosefinding/efftox/__init__.py
+++ b/clintrials/dosefinding/efftox/__init__.py
@@ -1,7 +1,7 @@
 from .design import (
     EffTox,
-    LpNormCurve,
     InverseQuadraticCurve,
+    LpNormCurve,
     efftox_dtp_detail,
     solve_metrizable_efftox_scenario,
 )

--- a/clintrials/dosefinding/efftox/design.py
+++ b/clintrials/dosefinding/efftox/design.py
@@ -1019,9 +1019,7 @@ def solve_metrizable_efftox_scenario(
     conform_util = np.where(conform, util, -np.inf)
 
     if np.all(np.isnan(util)):
-        logging.warning(
-            "All NaN util encountered in solve_metrizable_efftox_scenario"
-        )
+        logging.warning("All NaN util encountered in solve_metrizable_efftox_scenario")
         return conform, util, np.nan, -1, np.nan
     elif np.all(np.isnan(conform_util)):
         logging.warning(

--- a/tests/test_coll.py
+++ b/tests/test_coll.py
@@ -1,12 +1,17 @@
 import pytest
+
 from clintrials.coll import to_1d_list
 
-@pytest.mark.parametrize('value,expected', [
-    (0, [0]),
-    ([1, 2, 3], [1, 2, 3]),
-    ([[1, 2], 3, [4, 5]], [1, 2, 3, 4, 5]),
-    ([[1, [2, [3]]]], [1, 2, 3]),
-    ((1, 2), [(1, 2)]),
-])
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (0, [0]),
+        ([1, 2, 3], [1, 2, 3]),
+        ([[1, 2], 3, [4, 5]], [1, 2, 3, 4, 5]),
+        ([[1, [2, [3]]]], [1, 2, 3]),
+        ((1, 2), [(1, 2)]),
+    ],
+)
 def test_to_1d_list(value, expected):
     assert to_1d_list(value) == expected

--- a/tests/test_threeplusthree.py
+++ b/tests/test_threeplusthree.py
@@ -1,4 +1,5 @@
 import pytest
+
 from clintrials.dosefinding import ThreePlusThree
 
 

--- a/tests/test_tte_module.py
+++ b/tests/test_tte_module.py
@@ -1,6 +1,7 @@
 import numpy as np
-from clintrials.tte import BayesianTimeToEvent, matrix_cohort_analysis
+
 from clintrials.recruitment import ConstantRecruitmentStream
+from clintrials.tte import BayesianTimeToEvent, matrix_cohort_analysis
 
 
 def test_bayesian_time_to_event_update_and_test():
@@ -8,14 +9,14 @@ def test_bayesian_time_to_event_update_and_test():
     trial.update([(5, 0), (10, 0)])
 
     res = trial.test(time=5, cutoff=8, probability=0.8, less_than=True)
-    assert res['Patients'] == 2
-    assert res['Events'] == 0
-    assert abs(res['Probability'] - 0.69301655) < 1e-6
-    assert not res['Stop']
+    assert res["Patients"] == 2
+    assert res["Events"] == 0
+    assert abs(res["Probability"] - 0.69301655) < 1e-6
+    assert not res["Stop"]
 
     res = trial.test(time=12, cutoff=8, probability=0.5, less_than=False)
-    assert res['Events'] == 2
-    assert res['Stop']
+    assert res["Events"] == 2
+    assert res["Stop"]
 
 
 def test_matrix_cohort_analysis_deterministic():
@@ -36,8 +37,8 @@ def test_matrix_cohort_analysis_deterministic():
         final_analysis_time_delta=0,
         recruitment_stream=stream,
     )
-    assert report['Decision'] == 'StopAtInterim'
-    assert report['FinalPatients'] == 1
+    assert report["Decision"] == "StopAtInterim"
+    assert report["FinalPatients"] == 1
 
 
 def test_matrix_cohort_analysis_multiple_runs():


### PR DESCRIPTION
## Summary
- run `pre-commit` formatting tools

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_6883a475c074832c9f5d96edccee5a42