### PR TITLE
Fix release workflow python version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Install Poetry
         run: |
           python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.9"
 ggplot = ">=0.6.5"
 matplotlib = ">=1.4.3"
 numpy = ">=1.9.2"


### PR DESCRIPTION
## Summary
- use Python 3.10 in release workflow
- require Python 3.9+ in pyproject.toml

## Testing
- `pre-commit run --files .github/workflows/release.yml pyproject.toml`
- `pytest -q` *(fails: test_watu_1, test_watu_2)*

------
https://chatgpt.com/codex/tasks/task_e_6883a4c37828832ca8abd28bb1cd9f1c