### PR TITLE
Update workflows for Python >=3.9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Install Poetry
         run: |
           python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is provided "as-is" and the author accepts absolutely no responsibility whats
 * I expect to add more designs in the future.
 * It is written in pure Python, intentionally. This library would be quicker if it was written in C++ or Java but it would not be as portable or readable.
 * Some of the code is fairly mature but the repo itself is young and in flux.
-* This project now requires Python 3.8 or newer.
+* This project now requires Python 3.9 or newer.
 
 Why Python?
 ----

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ What does clintrials do?
 * I expect to add more designs in the future.
 * It is written in pure Python, intentionally. This library would be quicker if it was written in C++ or Java but it would not be as portable or readable.
 * Some of the code is fairly mature but the repo itself is young and in flux.
-* This project now requires Python 3.8 or newer.
+* This project now requires Python 3.9 or newer.
 
 
 Why Python?

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Clintrials requires Python 3.8 or later. Install from PyPI with:
+Clintrials requires Python 3.9 or later. Install from PyPI with:
 
 ```bash
 pip install clintrials

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/brockk/clintrials"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -18,7 +17,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.9"
 ggplot = ">=0.6.5"
 matplotlib = ">=1.4.3"
 numpy = ">=1.9.2"


### PR DESCRIPTION
## Summary
- bump release workflow to Python 3.10
- require Python >=3.9 in pyproject
- drop Python 3.8 classifier
- update docs to state Python 3.9+

## Testing
- `pytest -q` *(fails: tests/test_watu.py::test_watu_1 - assert -1 == 2)*

------
https://chatgpt.com/codex/tasks/task_e_6883a4c37828832ca8abd28bb1cd9f1c