### PR TITLE
Fix changelog doc reference

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,6 @@
 # Changelog
 
-This project maintains its release history in the root [CHANGELOG.md](../CHANGELOG.md).
+This project maintains its release history in the repository root. See the
+`CHANGELOG.md` file for the complete log of changes.
 
 ## v0.1.4 – initial release


### PR DESCRIPTION
## Summary
- fix the link in docs/changelog.md to avoid referencing outside the docs tree

## Testing
- `make html` in `docs`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883a9a6f3c0832c9eea14827c611fc1