### PR TITLE
Update CI to drop Python 3.8

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
## Summary
- update CI workflow to remove unsupported Python 3.8

## Testing
- `pytest -q -p no:warnings`

------
https://chatgpt.com/codex/tasks/task_e_6883aa0d5d48832cadb23011d7640918