### PR TITLE
Fix tests using local package

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure the project root is on sys.path so local 'clintrials' package is used
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)


### PR DESCRIPTION
## Summary
- ensure tests import the local `clintrials` package

## Testing
- `python -m pytest -q --cov=clintrials --cov-report=term --cov-report=xml`

------
https://chatgpt.com/codex/tasks/task_e_6883acf9bae8832cb7beebc6a8e3f2a7