### PR TITLE
Add pytest-cov to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ furo = {version = "^2024.1.29", optional = true}
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.2.0"
+pytest-cov = "^4.1.0"
 black = "^25.1.0"
 ruff = "^0.12.5"
 isort = "^6.0.1"


### PR DESCRIPTION
## Summary
- add `pytest-cov` so coverage options work

## Testing
- `pytest --cov=clintrials -q`

------
https://chatgpt.com/codex/tasks/task_e_6883acc85528832c9194ea3f3dd3be4c