### PR TITLE
Add final analysis test for TTE

### DIFF
--- a/tests/test_tte_module.py
+++ b/tests/test_tte_module.py
@@ -61,3 +61,24 @@ def test_matrix_cohort_analysis_multiple_runs():
     )
     assert isinstance(reports, list)
     assert len(reports) == 2
+
+
+def test_matrix_cohort_analysis_go_at_final():
+    np.random.seed(0)
+    stream = ConstantRecruitmentStream(1)
+    report = matrix_cohort_analysis(
+        n_simulations=1,
+        n_patients=2,
+        true_median=5,
+        alpha_prior=2,
+        beta_prior=2,
+        lower_cutoff=2,
+        upper_cutoff=4,
+        interim_certainty=0.2,
+        final_certainty=0.1,
+        interim_analysis_after_patients=[],
+        interim_analysis_time_delta=0,
+        final_analysis_time_delta=0,
+        recruitment_stream=stream,
+    )
+    assert report["Decision"] == "GoAtFinal"


### PR DESCRIPTION
## Summary
- add test to verify `matrix_cohort_analysis` can return `GoAtFinal`

## Testing
- `coverage run -m pytest -q`
- `coverage report`

------
https://chatgpt.com/codex/tasks/task_e_6883acc85528832c9194ea3f3dd3be4c