### PR TITLE
Fix docs workflow deployment branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,7 @@ on:
       - "clintrials/**"
       - "pyproject.toml"
   push:
-    branches: [main]
+    branches: [main, gh-pages]
     paths:
       - "docs/**"
       - "clintrials/**"
@@ -55,6 +55,7 @@ jobs:
           path: ./_site
 
   deploy:
+    if: github.ref == 'refs/heads/gh-pages'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/README.md
+++ b/README.md
@@ -126,6 +126,6 @@ pip install -e .[docs]
 make -C docs html
 ```
 
-Documentation changes pushed to `main` are automatically deployed to
+Documentation changes pushed to `gh-pages` are automatically deployed to
 GitHub Pages using a Jekyll workflow defined in
 `.github/workflows/docs.yml`.


### PR DESCRIPTION
## Summary
- adjust docs workflow to deploy from `gh-pages` only
- update README to mention `gh-pages` deployment

## Testing
- `pre-commit run --all-files --show-diff-on-failure`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b9c011ac832cba257f2649bc61df