### PR TITLE
Remove TODO comments and list tasks

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,32 @@
+# Outstanding TODOs
+
+The following tasks were extracted from TODO comments removed across the codebase.
+
+- **clintrials/dosefinding/watu.py**
+  - Parameter `must_try_lowest_dose` in `__init__` is currently unused.
+  - Replace the Monte Carlo approach in `prob_eff_exceeds` with a proper posterior integral.
+  - Allow the sample size `n=10**5` used in `_stage_one_next_dose` to be configurable.
+  - Allow the sample size `n=10**5` used in `_stage_two_next_dose` to be configurable.
+- **clintrials/dosefinding/crm/design.py**
+  - Investigate how variance estimation is possible in `_get_beta_hat_mle`.
+- **clintrials/dosefinding/efftox/design.py**
+  - Ensure integration limits fully cover the posterior range for accurate estimation (appears in two functions).
+  - Implement the `solve` method that should return the un-specified probability for a given `delta`.
+  - Replace the placeholder parameter means and standard deviations currently taken from MD Anderson's EffTox software.
+- **clintrials/recruitment.py**
+  - Clarify whether zero or negative values are allowed for `initial_intensity` in `Recruitment`
+    initialization.
+- **clintrials/phase2/bebop/peps2v1.py**
+  - Complete the docstring for `get_posterior_probs` to describe the trial correctly.
+  - Implement confidence interval calculation for correlation in the commented `correlation_effect` method.
+- **clintrials/phase2/bebop/__init__.py**
+  - Write a full docstring for `update` describing parameters and behaviour.
+- **clintrials/simulation.py**
+  - Provide handling for non-pandas outputs in `extract_sim_data` (`TODO` placeholders currently return raw tuples and lists).
+  - Review whether the helper functions at the end of the module belong in a general package.
+- **tests/test_crm.py**
+  - Add tests of the full Bayesian CRM verified against the `bcrm` R package.
+- **tests/test_efftox.py**
+  - Add dedicated tests for the EffTox implementation.
+- **tutorials/CRM.ipynb**
+  - Replace the placeholder markdown cell containing "TODO" with actual content.

--- a/clintrials/dosefinding/crm/design.py
+++ b/clintrials/dosefinding/crm/design.py
@@ -174,8 +174,6 @@ def _get_beta_hat_bayes(
 def _get_beta_hat_mle(F, intercept, codified_doses_given, toxs, estimate_var=False):
     """Get maximum likelihood estimate of beta parameter (and optionally its variance) in MLE CRM.
 
-    TODO: how is estimating variance possible?
-
     :param F: link function like logistic or empiric, taking params (dose_label, intercept, slope), returns probability
     :type F: func
     :param intercept: the second parameter to F, the intercept

--- a/clintrials/dosefinding/efftox/design.py
+++ b/clintrials/dosefinding/efftox/design.py
@@ -133,7 +133,7 @@ def efftox_get_posterior_probs(
     # 6 dimensions. The limits of integration should capture all probability density, but not be too
     # generous, e.g. -1000 to 1000 would be stupid because the density at most points would be practically zero.
     # I use percentage points of the various prior distributions. The risk is that if the prior
-    # does not cover the posterior range well, it will not estimate it well. This needs attention. TODO
+    # does not cover the posterior range well, it will not estimate it well. This needs attention.
     epsilon = 0.000001
     limits = [(dist.ppf(epsilon), dist.ppf(1 - epsilon)) for dist in priors]
     samp = np.column_stack(
@@ -213,7 +213,7 @@ def efftox_get_posterior_params(cases, priors, scaled_doses, n=10**5):
     # 6 dimensions. The limits of integration should capture all probability density, but not be too
     # generous, e.g. -1000 to 1000 would be stupid because the density at most points would be practically zero.
     # I use percentage points of the various prior distributions. The risk is that if the prior
-    # does not cover the posterior range well, it will not estimate it well. This needs attention. TODO
+    # does not cover the posterior range well, it will not estimate it well. This needs attention.
     epsilon = 0.000001
     limits = [(dist.ppf(epsilon), dist.ppf(1 - epsilon)) for dist in priors]
     samp = np.column_stack(
@@ -486,7 +486,6 @@ class InverseQuadraticCurve:
 
     def solve(self, prob_eff=None, prob_tox=None, delta=0):
         """Specify exactly one of prob_eff or prob_tox and this will return the other, for given delta"""
-        # TODO
         raise NotImplementedError()
 
     def plot_contours(
@@ -536,7 +535,7 @@ class EffTox(EfficacyToxicityDoseFindingTrial):
     See Thall, P.F. & Cook, J.D. (2004) - Dose-Finding Based on Efficacy-Toxicity Trade-Offs
 
     e.g. general usage
-    (for now, parameter means and standard deviations were fetched from MD Anderson's EffTox software. TODO)
+    (for now, parameter means and standard deviations were fetched from MD Anderson's EffTox software.)
     >>> real_doses = [7.5, 15, 30, 45]
     >>> tox_cutoff = 0.40
     >>> eff_cutoff = 0.45

--- a/clintrials/dosefinding/watu.py
+++ b/clintrials/dosefinding/watu.py
@@ -154,7 +154,7 @@ class WATU(EfficacyToxicityDoseFindingTrial):
         :param avoid_skipping_untried_deescalation_stage_2: True to avoid skipping untried doses in de-escalation in
         stage 2
         :type avoid_skipping_untried_deescalation_stage_2: bool
-        :param must_try_lowest_dose: Unused, TODO
+        :param must_try_lowest_dose: Unused
         :type must_try_lowest_dose: bool
         :param plugin_mean: True to estimate event curves by plugging parameter estimate into function;
                             False to estimate using full Bayesian integral (default).
@@ -343,7 +343,6 @@ class WATU(EfficacyToxicityDoseFindingTrial):
         # Estimate probability of efficacy exceeds eff_cutoff using plug-in mean and variance for theta
         # and randomly sampling values from normal. Why normal? Because the prior for is normal and the posterior
         # is asymptotically normal. For low n, non-normality may lead to bias.
-        # TODO: research replacing this with a proper posterior integral
         theta_sample = norm(
             loc=self.model_theta_hat(), scale=np.sqrt(self.model_theta_var())
         ).rvs(n)
@@ -368,7 +367,7 @@ class WATU(EfficacyToxicityDoseFindingTrial):
 
         prob_unacc_tox = self.crm.prob_tox_exceeds(
             self.tox_limit, n=10**5
-        )  # TODO: make n=10**5 editable
+        )
         prob_unacc_eff = 1 - self.prob_eff_exceeds(self.eff_limit, n=10**5)
         admissable = [
             (prob_tox < (1 - self.tox_certainty))
@@ -426,7 +425,7 @@ class WATU(EfficacyToxicityDoseFindingTrial):
 
         prob_unacc_tox = self.crm.prob_tox_exceeds(
             self.tox_limit, n=10**5
-        )  # TODO: make n=10**5 editable
+        )
         prob_unacc_eff = 1 - self.prob_eff_exceeds(self.eff_limit, n=10**5)
         admissable = [
             (prob_tox < (1 - self.tox_certainty))

--- a/clintrials/phase2/bebop/__init__.py
+++ b/clintrials/phase2/bebop/__init__.py
@@ -103,7 +103,7 @@ class BeBOP:
         return [case[i] for case in self.cases]
 
     def update(self, cases, n=10**6, epsilon=0.00001, **kwargs):
-        """TODO
+        """Update the sampler with additional ``cases``.
 
         :param n:
         :param epsilon:

--- a/clintrials/phase2/bebop/peps2v1.py
+++ b/clintrials/phase2/bebop/peps2v1.py
@@ -82,7 +82,7 @@ def l_n(D, alpha0, beta0, beta1, beta2, psi):
 
 
 def get_posterior_probs(D, priors, tox_cutoffs, eff_cutoffs, n=10**5):
-    """Get the posterior probabilities after having observed cumulative data D in a TODO trial.
+    """Get the posterior probabilities after having observed cumulative data ``D`` in a trial.
 
     Note: This function evaluates the posterior integrals using Monte Carlo integration. Thall & Cook
     use the method of Monahan & Genz. I imagine that is quicker and more accurate but it is also
@@ -408,7 +408,7 @@ class PePS2BeBOP:
 #
 #     def correlation_effect(self, alpha=0.05):
 #         """ Get confidence interval and mean estimate of the correlation between efficacy and toxicity. """
-#         # TODO: Confidence interval for correlation is described here
+#         # Confidence interval for correlation is described here
 #         # http://ncss.wpengine.netdna-cdn.com/wp-content/themes/ncss/pdf/Procedures/PASS/Confidence_Interval_for_Pearsons_Correlation.pdf
 #         return [-1, np.corrcoef(self.toxicities(), self.efficacies())[0,1], 1]
 #

--- a/clintrials/recruitment.py
+++ b/clintrials/recruitment.py
@@ -157,7 +157,7 @@ class QuadrilateralRecruitmentStream(RecruitmentStream):
         :param initial_intensity: recruitment commences at this % of total power.
                                     E.g. if it takes 2 days to recruit a patient at full recruitment power,
                                             at intensity 0.1 it will take 20 days to recruit a patient.
-                                    TODO: zero? negative?
+                                    Zero? negative?
         :type initial_intensity: float
         :param vertices: list of additional vertices as (time t, intensity r) tuples, where recruitment power is r% at t
                         Recruitment intensity is linearly extrapolated between vertex times, including the origin, t=0.

--- a/clintrials/simulation.py
+++ b/clintrials/simulation.py
@@ -179,7 +179,6 @@ def summarise_sims(sims, ps, func_map, var_map=None, to_pandas=True):
                 row_tuples, pd.MultiIndex.from_tuples(index_tuples, names=var_names)
             )
         else:
-            # TODO
             return row_tuples, index_tuples
     else:
         if to_pandas:
@@ -187,7 +186,6 @@ def summarise_sims(sims, ps, func_map, var_map=None, to_pandas=True):
 
             return pd.DataFrame(columns=func_map.keys())
         else:
-            # TODO
             return [], []
 
 
@@ -251,7 +249,6 @@ def reduce_maps_by_summing(x, y):
 
 
 # I wrote the functions below during a specific analysis.
-# TODO: Do they make sense in a general package?
 def partition_and_aggregate(sims, ps, function_map):
     """Function partitions simulations into subsets that used the same set of parameters,
     and then invokes a collection of map/reduce function pairs on each subset.

--- a/tests/test_crm.py
+++ b/tests/test_crm.py
@@ -243,4 +243,3 @@ def test_CRM_bayes_again():
     # These are verifiable in R
 
 
-# TODO: tests of full Bayes CRM, verified against bcrm in R

--- a/tests/test_efftox.py
+++ b/tests/test_efftox.py
@@ -1,8 +1,6 @@
 __author__ = "Kristian Brock"
 __contact__ = "kristian.brock@gmail.com"
 
-# TODO
-
 # from nose.tools import with_setup
 from collections import OrderedDict
 

--- a/tutorials/CRM.ipynb
+++ b/tutorials/CRM.ipynb
@@ -306,7 +306,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "TODO"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- move all TODO notes into TODO.md and eliminate inline TODO comments
- tweak wording in docstrings and comments
- leave placeholders for future tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888cecfcebc832c84f5fed8c173f495