### PR TITLE
Refactor: Move generic helpers from simulation to utils

### DIFF
--- a/clintrials/dosefinding/__init__.py
+++ b/clintrials/dosefinding/__init__.py
@@ -14,13 +14,13 @@ from itertools import combinations_with_replacement, product
 import numpy as np
 from scipy.stats import uniform
 
-from clintrials.simulation import filter_sims
 from clintrials.util import (
     atomic_to_json,
     correlated_binary_outcomes_from_uniforms,
     iterable_to_json,
     to_1d_list,
 )
+from clintrials.utils import filter_list_of_dicts
 
 logger = logging.getLogger(__name__)
 
@@ -712,7 +712,7 @@ def summarise_dose_finding_sims(sims, label, num_doses, filter={}):
     import pandas as pd
 
     if len(filter):
-        sims = filter_sims(sims, filter)
+        sims = filter_list_of_dicts(sims, filter)
 
     # Recommended Doses
     doses = [x[label]["RecommendedDose"] for x in sims]

--- a/clintrials/simulation.py
+++ b/clintrials/simulation.py
@@ -2,12 +2,22 @@ __author__ = "Kristian Brock"
 __contact__ = "kristian.brock@gmail.com"
 
 
-import glob
 import itertools
 import json
 import logging
+import warnings
 from collections import OrderedDict
 from datetime import datetime
+
+from clintrials.utils import (
+    _open_json_local,
+    fetch_json_from_files,
+    filter_list_of_dicts,
+    invoke_map_reduce_on_list,
+    map_reduce_files,
+    multiindex_dataframe_from_tuple_map,
+    reduce_maps_by_summing,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -88,44 +98,20 @@ def sim_parameter_space(sim_func, ps, n1=1, n2=None, out_file=None):
     return sims
 
 
-def _open_json_local(file_loc):
-    return json.load(open(file_loc))
-
-
-def _open_json_url(url):
-    from urllib.request import urlopen
-
-    return json.load(urlopen(url))
-
-
 def go_fetch_json_sims(file_pattern):
-    files = glob.glob(file_pattern)
-    sims = []
-    for f in files:
-        sub_sims = _open_json_local(f)
-        logger.info("%s %s", f, len(sub_sims))
-        sims += sub_sims
-    logger.info("Fetched %s sims", len(sims))
-    return sims
+    warnings.warn(
+        "go_fetch_json_sims is deprecated; use fetch_json_from_files instead",
+        DeprecationWarning,
+    )
+    return fetch_json_from_files(file_pattern)
 
 
-def filter_sims(sims, filter):
-    """Filter a list of simulations.
-
-    :param sims: list of simulations (probably in JSON format)
-    :type sims: list
-    :param filter: map of item -> value pairs that forms the filter. Exact matches are retained.
-    :type filter: dict
-
-    """
-
-    for key, val in filter.items():
-        # In JSON, tuples are masked as lists. In this filter, we treat them as equivalent:
-        if isinstance(val, (tuple)):
-            sims = [x for x in sims if x[key] == val or x[key] == list(val)]
-        else:
-            sims = [x for x in sims if x[key] == val]
-    return sims
+def filter_sims(sims, filter_dict):
+    warnings.warn(
+        "filter_sims is deprecated; use filter_list_of_dicts instead",
+        DeprecationWarning,
+    )
+    return filter_list_of_dicts(sims, filter_dict)
 
 
 def summarise_sims(sims, ps, func_map, var_map=None, to_pandas=True):
@@ -163,7 +149,7 @@ def summarise_sims(sims, ps, func_map, var_map=None, to_pandas=True):
     row_tuples = []
     for param_combo in param_combinations:
         these_params = dict(zip(labels, param_combo))
-        these_sims = filter_sims(sims, these_params)
+        these_sims = filter_list_of_dicts(sims, these_params)
         if len(these_sims):
             these_metrics = {
                 label: func(these_sims, these_params)
@@ -189,63 +175,12 @@ def summarise_sims(sims, ps, func_map, var_map=None, to_pandas=True):
             return [], []
 
 
-# Map-Reduce methods for summarising sims in memory-efficient ways
-def map_reduce_files(files, map_func, reduce_func):
-    """
-    Invoke map_func on each file in sim_files and reduce results using reduce_func.
-
-    :param files: list of files that contain simulations
-    :type files: list
-    :param map_func:function to create summary content for object x
-    :type map_func: function
-    :param reduce_func: function to reduce summary content of objects x & y
-    :type reduce_func: function
-
-    :returns: ?
-    :rtype: ?
-
-    """
-    if len(files):
-        x = map(map_func, files)
-        return reduce(reduce_func, x)
-    else:
-        raise TypeError("No files")
-
-
 def invoke_map_reduce_function_map(sims, function_map):
-    """Invokes map/reduce pattern for many items on a list of simulations.
-    Functions are specified as "item name" -> (map_func, reduce_func) pairs in function_map.
-    In each iteration, map_func is invoked on sims, and then reduce_func is invoked on result.
-    As usual, map_func takes iterable as single argument and reduce_func takes x and y as args.
-
-    Returns a dict with keys function_map.keys() and values the result of reduce_func
-    """
-
-    response = OrderedDict()
-    for item, function_tuple in function_map.items():
-        map_func, reduce_func = function_tuple
-        x = reduce(reduce_func, map(map_func, sims))
-        response[item] = x
-
-    return response
-
-
-def reduce_maps_by_summing(x, y):
-    """Reduces maps x and y by adding the value of every item in x to matching value in y.
-
-    :param x: first map
-    :type x: dict
-    :param y: second map
-    :type y: dict
-    :returns: map of summed values
-    :rtype: dict
-
-    """
-
-    response = OrderedDict()
-    for k in x.keys():
-        response[k] = x[k] + y[k]
-    return response
+    warnings.warn(
+        "invoke_map_reduce_function_map is deprecated; use invoke_map_reduce_on_list instead",
+        DeprecationWarning,
+    )
+    return invoke_map_reduce_on_list(sims, function_map)
 
 
 # I wrote the functions below during a specific analysis.
@@ -273,9 +208,9 @@ def partition_and_aggregate(sims, ps, function_map):
     for param_combo in param_combinations:
 
         these_params = dict(zip(labels, param_combo))
-        these_sims = filter_sims(sims, these_params)
+        these_sims = filter_list_of_dicts(sims, these_params)
 
-        out[param_combo] = invoke_map_reduce_function_map(these_sims, function_map)
+        out[param_combo] = invoke_map_reduce_on_list(these_sims, function_map)
 
     return out
 
@@ -310,18 +245,24 @@ def reduce_product_of_two_files_by_summing(x, y):
 
 
 def multiindex_dataframe_from_tuple_map(x, labels):
-    """Create pandas.DataFrame from map of param-tuple -> value
+    warnings.warn(
+        "multiindex_dataframe_from_tuple_map is deprecated; use multiindex_dataframe_from_tuple_map from clintrials.utils instead",
+        DeprecationWarning,
+    )
+    return multiindex_dataframe_from_tuple_map(x, labels)
 
-    :param x: map of parameter-tuple -> value pairs
-    :type x: dict
-    :param labels: list of item labels
-    :type labels: list
-    :returns: DataFrame object
-    :rtype: pandas.DataFrame
 
-    """
-    import pandas as pd
+def reduce_maps_by_summing(x, y):
+    warnings.warn(
+        "reduce_maps_by_summing is deprecated; use reduce_maps_by_summing from clintrials.utils instead",
+        DeprecationWarning,
+    )
+    return reduce_maps_by_summing(x, y)
 
-    k, v = zip(*[(k, v) for (k, v) in x.items()])
-    i = pd.MultiIndex.from_tuples(k, names=labels)
-    return pd.DataFrame(list(v), index=i)
+
+def map_reduce_files(files, map_func, reduce_func):
+    warnings.warn(
+        "map_reduce_files is deprecated; use map_reduce_files from clintrials.utils instead",
+        DeprecationWarning,
+    )
+    return map_reduce_files(files, map_func, reduce_func)

--- a/clintrials/utils.py
+++ b/clintrials/utils.py
@@ -1,0 +1,125 @@
+__author__ = "Kristian Brock"
+__contact__ = "kristian.brock@gmail.com"
+
+import glob
+import json
+import logging
+from collections import OrderedDict
+from functools import reduce
+
+logger = logging.getLogger(__name__)
+
+
+def _open_json_local(file_loc):
+    return json.load(open(file_loc))
+
+
+def _open_json_url(url):
+    from urllib.request import urlopen
+
+    return json.load(urlopen(url))
+
+
+def fetch_json_from_files(file_pattern):
+    files = glob.glob(file_pattern)
+    sims = []
+    for f in files:
+        sub_sims = _open_json_local(f)
+        logger.info("%s %s", f, len(sub_sims))
+        sims += sub_sims
+    logger.info("Fetched %s sims", len(sims))
+    return sims
+
+
+def filter_list_of_dicts(list_of_dicts, filter_dict):
+    """Filter a list of dictionaries.
+
+    :param list_of_dicts: list of dictionaries
+    :type list_of_dicts: list
+    :param filter_dict: map of item -> value pairs that forms the filter. Exact matches are retained.
+    :type filter_dict: dict
+
+    """
+    for key, val in filter_dict.items():
+        # In JSON, tuples are masked as lists. In this filter, we treat them as equivalent:
+        if isinstance(val, (tuple)):
+            list_of_dicts = [x for x in list_of_dicts if x[key] == val or x[key] == list(val)]
+        else:
+            list_of_dicts = [x for x in list_of_dicts if x[key] == val]
+    return list_of_dicts
+
+
+def map_reduce_files(files, map_func, reduce_func):
+    """
+    Invoke map_func on each file in sim_files and reduce results using reduce_func.
+
+    :param files: list of files that contain simulations
+    :type files: list
+    :param map_func:function to create summary content for object x
+    :type map_func: function
+    :param reduce_func: function to reduce summary content of objects x & y
+    :type reduce_func: function
+
+    :returns: ?
+    :rtype: ?
+
+    """
+    if len(files):
+        x = map(map_func, files)
+        return reduce(reduce_func, x)
+    else:
+        raise TypeError("No files")
+
+
+def invoke_map_reduce_on_list(a_list, function_map):
+    """Invokes map/reduce pattern for many items on a list.
+    Functions are specified as "item name" -> (map_func, reduce_func) pairs in function_map.
+    In each iteration, map_func is invoked on sims, and then reduce_func is invoked on result.
+    As usual, map_func takes iterable as single argument and reduce_func takes x and y as args.
+
+    Returns a dict with keys function_map.keys() and values the result of reduce_func
+    """
+
+    response = OrderedDict()
+    for item, function_tuple in function_map.items():
+        map_func, reduce_func = function_tuple
+        x = reduce(reduce_func, map(map_func, a_list))
+        response[item] = x
+
+    return response
+
+
+def reduce_maps_by_summing(x, y):
+    """Reduces maps x and y by adding the value of every item in x to matching value in y.
+
+    :param x: first map
+    :type x: dict
+    :param y: second map
+    :type y: dict
+    :returns: map of summed values
+    :rtype: dict
+
+    """
+
+    response = OrderedDict()
+    for k in x.keys():
+        response[k] = x[k] + y[k]
+    return response
+
+
+def multiindex_dataframe_from_tuple_map(x, labels):
+    """Create pandas.DataFrame from map of param-tuple -> value
+
+    :param x: map of parameter-tuple -> value pairs
+    :type x: dict
+    :param labels: list of item labels
+    :type labels: list
+    :returns: DataFrame object
+    :rtype: pandas.DataFrame
+
+    """
+    import pandas as pd
+
+    k, v = zip(*[(k, v) for (k, v) in x.items()])
+    i = pd.MultiIndex.from_tuples(k, names=labels)
+    return pd.DataFrame(list(v), index=i)


### PR DESCRIPTION
This refactoring moves generic helper functions from `clintrials/simulation.py` to a new `clintrials/utils.py` module. This improves code organization, promotes reusability, and helps to avoid potential circular dependencies.

The following functions were moved:
- `_open_json_local`
- `_open_json_url`
- `go_fetch_json_sims` (renamed to `fetch_json_from_files`)
- `filter_sims` (renamed to `filter_list_of_dicts`)
- `map_reduce_files`
- `invoke_map_reduce_function_map` (renamed to `invoke_map_reduce_on_list`)
- `reduce_maps_by_summing`
- `multiindex_dataframe_from_tuple_map`

Deprecation shims have been added to `clintrials/simulation.py` for all moved functions to ensure backward compatibility. All internal references to these functions have been updated to use the new `clintrials.utils` module.