### PR TITLE
Add win-ratio power simulation module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It is provided "as-is" and the author accepts absolutely no responsibility whats
 * This library implements some designs used in clinical trials.
 * It has implementations of O'Quigley's CRM design, Thall & Cook's EffTox design, and Wages & Tait's efficacy+toxicity design.
 * There is also an implementation of my very own BEBOP trial design for the simultaneous study of bivariate binary outcomes (like efficacy and toxicity) in the presence of predictive variables, both continuous and binary.
+* A win-ratio simulation module estimates the power of hierarchical composite endpoints.
 * There is a bias towards phase I and II trial designs because that is my research area.
 * I expect to add more designs in the future.
 * It is written in pure Python, intentionally. This library would be quicker if it was written in C++ or Java but it would not be as portable or readable.

--- a/clintrials/winratio/__init__.py
+++ b/clintrials/winratio/__init__.py
@@ -1,0 +1,21 @@
+"""Win-ratio simulation utilities."""
+
+from .compare import compare_subjects
+from .data_generation import generate_data
+from .main import run_simulation
+from .simulate import simulate_comparisons
+from .statistics import (
+    calculate_confidence_intervals,
+    calculate_p_value,
+    calculate_win_ratio,
+)
+
+__all__ = [
+    "compare_subjects",
+    "generate_data",
+    "simulate_comparisons",
+    "calculate_confidence_intervals",
+    "calculate_p_value",
+    "calculate_win_ratio",
+    "run_simulation",
+]

--- a/clintrials/winratio/compare.py
+++ b/clintrials/winratio/compare.py
@@ -1,0 +1,25 @@
+"""Compare two subjects component-wise in a hierarchical manner."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def compare_subjects(subject1: Iterable[int], subject2: Iterable[int]) -> str:
+    """Compare two subjects across multiple components hierarchically.
+
+    The first differing component determines the winner. Higher values are better.
+
+    Args:
+        subject1: Outcomes for the first subject.
+        subject2: Outcomes for the second subject.
+
+    Returns:
+        'win' if subject1 wins, 'loss' if subject1 loses, or 'tie'.
+    """
+    for i in range(len(subject1)):
+        if subject1[i] > subject2[i]:
+            return "win"
+        if subject1[i] < subject2[i]:
+            return "loss"
+    return "tie"

--- a/clintrials/winratio/data_generation.py
+++ b/clintrials/winratio/data_generation.py
@@ -1,0 +1,51 @@
+"""Generate synthetic data for win-ratio simulations."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def generate_data(
+    num_subjects_A: int,
+    num_subjects_B: int,
+    p_y1_A: float,
+    p_y1_B: float,
+    p_y2_A: float,
+    p_y2_B: float,
+    p_y3_A: float,
+    p_y3_B: float,
+):
+    """Generate data for treatment (A) and control (B) groups.
+
+    Each subject has three binary outcomes (y1, y2, y3).
+
+    Args:
+        num_subjects_A: Number of subjects in Group A.
+        num_subjects_B: Number of subjects in Group B.
+        p_y1_A: Probability of outcome ``y1`` equals 1 for Group A.
+        p_y1_B: Probability of outcome ``y1`` equals 1 for Group B.
+        p_y2_A: Probability of outcome ``y2`` equals 1 for Group A.
+        p_y2_B: Probability of outcome ``y2`` equals 1 for Group B.
+        p_y3_A: Probability of outcome ``y3`` equals 1 for Group A.
+        p_y3_B: Probability of outcome ``y3`` equals 1 for Group B.
+
+    Returns:
+        Two arrays representing the subjects in Groups A and B respectively.
+    """
+    group_A = np.vstack(
+        [
+            np.random.binomial(1, p_y1_A, num_subjects_A),
+            np.random.binomial(1, p_y2_A, num_subjects_A),
+            np.random.binomial(1, p_y3_A, num_subjects_A),
+        ]
+    ).T
+
+    group_B = np.vstack(
+        [
+            np.random.binomial(1, p_y1_B, num_subjects_B),
+            np.random.binomial(1, p_y2_B, num_subjects_B),
+            np.random.binomial(1, p_y3_B, num_subjects_B),
+        ]
+    ).T
+
+    return group_A, group_B

--- a/clintrials/winratio/main.py
+++ b/clintrials/winratio/main.py
@@ -1,0 +1,119 @@
+"""Command-line entry point for win-ratio power simulations."""
+
+from __future__ import annotations
+
+import argparse
+
+from .data_generation import generate_data
+from .simulate import simulate_comparisons
+from .statistics import (
+    calculate_confidence_intervals,
+    calculate_p_value,
+    calculate_win_ratio,
+)
+
+
+def run_simulation(
+    num_subjects_A: int,
+    num_subjects_B: int,
+    num_simulations: int,
+    p_y1_A: float,
+    p_y1_B: float,
+    p_y2_A: float,
+    p_y2_B: float,
+    p_y3_A: float,
+    p_y3_B: float,
+    significance_level: float = 0.05,
+):
+    """Run a Monte Carlo simulation to estimate win-ratio power."""
+    successes = 0
+    all_cis = []
+    for _ in range(num_simulations):
+        treatment_group, control_group = generate_data(
+            num_subjects_A,
+            num_subjects_B,
+            p_y1_A,
+            p_y1_B,
+            p_y2_A,
+            p_y2_B,
+            p_y3_A,
+            p_y3_B,
+        )
+        results = simulate_comparisons(treatment_group, control_group)
+        wr = calculate_win_ratio(results["wins"], results["losses"])
+        if wr == float("inf"):
+            if results["wins"] > 0:
+                successes += 1
+            continue
+        ci = calculate_confidence_intervals(wr, results["wins"], results["losses"])
+        p_value = calculate_p_value(wr, results["wins"], results["losses"])
+        all_cis.append(ci)
+        if p_value < significance_level:
+            successes += 1
+    power = successes / num_simulations
+    if all_cis:
+        average_ci = (
+            sum(ci[0] for ci in all_cis) / len(all_cis),
+            sum(ci[1] for ci in all_cis) / len(all_cis),
+        )
+    else:
+        average_ci = (0, 0)
+    return power, average_ci
+
+
+def main() -> None:
+    """Parse command-line arguments and run the simulation."""
+    parser = argparse.ArgumentParser(
+        description="Run a win-ratio simulation to calculate statistical power."
+    )
+    parser.add_argument(
+        "--num_subjects_A", type=int, default=100, help="Number of subjects in Group A."
+    )
+    parser.add_argument(
+        "--num_subjects_B", type=int, default=50, help="Number of subjects in Group B."
+    )
+    parser.add_argument(
+        "--num_simulations", type=int, default=10000, help="Number of simulations."
+    )
+    parser.add_argument(
+        "--p_y1_A", type=float, default=0.50, help="Probability of y1=1 for Group A."
+    )
+    parser.add_argument(
+        "--p_y1_B", type=float, default=0.50, help="Probability of y1=1 for Group B."
+    )
+    parser.add_argument(
+        "--p_y2_A", type=float, default=0.75, help="Probability of y2=1 for Group A."
+    )
+    parser.add_argument(
+        "--p_y2_B", type=float, default=0.25, help="Probability of y2=1 for Group B."
+    )
+    parser.add_argument(
+        "--p_y3_A", type=float, default=0.43, help="Probability of y3=1 for Group A."
+    )
+    parser.add_argument(
+        "--p_y3_B", type=float, default=0.27, help="Probability of y3=1 for Group B."
+    )
+    parser.add_argument(
+        "--significance", type=float, default=0.05, help="Significance level."
+    )
+    args = parser.parse_args()
+    power, average_ci = run_simulation(
+        args.num_subjects_A,
+        args.num_subjects_B,
+        args.num_simulations,
+        args.p_y1_A,
+        args.p_y1_B,
+        args.p_y2_A,
+        args.p_y2_B,
+        args.p_y3_A,
+        args.p_y3_B,
+        args.significance,
+    )
+    print(f"Power of the test: {power:.4f}")  # noqa: T201
+    print(  # noqa: T201
+        "Average confidence interval: " f"({average_ci[0]:.4f}, {average_ci[1]:.4f})"
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    main()

--- a/clintrials/winratio/simulate.py
+++ b/clintrials/winratio/simulate.py
@@ -1,0 +1,30 @@
+"""Pairwise win-ratio comparisons between treatment and control subjects."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .compare import compare_subjects
+
+
+def simulate_comparisons(treatment_group, control_group) -> dict[str, int]:
+    """Compare every treatment subject with every control subject.
+
+    Args:
+        treatment_group: 2D array of subjects in the treatment group.
+        control_group: 2D array of subjects in the control group.
+
+    Returns:
+        Counts of wins, losses and ties for the treatment group.
+    """
+    results = {"wins": 0, "losses": 0, "ties": 0}
+    for treatment_subj in treatment_group:
+        for control_subj in control_group:
+            result = compare_subjects(treatment_subj, control_subj)
+            if result == "win":
+                results["wins"] += 1
+            elif result == "loss":
+                results["losses"] += 1
+            else:
+                results["ties"] += 1
+    return results

--- a/clintrials/winratio/statistics.py
+++ b/clintrials/winratio/statistics.py
@@ -1,0 +1,36 @@
+"""Statistical helpers for win-ratio simulations."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.stats import norm
+
+
+def calculate_confidence_intervals(wr: float, wins: int, losses: int):
+    """Calculate 95% confidence intervals for the win ratio."""
+    if wins == 0 or losses == 0:
+        return (0, 0)
+    variance = 1 / wins + 1 / losses
+    standard_error = np.sqrt(variance)
+    z_score = norm.ppf(0.975)
+    log_wr = np.log(wr)
+    lower_bound_log = log_wr - z_score * standard_error
+    upper_bound_log = log_wr + z_score * standard_error
+    lower_bound = np.exp(lower_bound_log)
+    upper_bound = np.exp(upper_bound_log)
+    return (lower_bound, upper_bound)
+
+
+def calculate_p_value(wr: float, wins: int, losses: int) -> float:
+    """Calculate the p-value for the observed win ratio."""
+    if wins == 0 or losses == 0:
+        return 1.0
+    observed_z = (np.log(wr)) / np.sqrt((1 / wins) + (1 / losses))
+    return 2 * norm.sf(abs(observed_z))
+
+
+def calculate_win_ratio(wins: int, losses: int) -> float:
+    """Return the win ratio or infinity if there are no losses."""
+    if losses == 0:
+        return float("inf")
+    return wins / losses

--- a/docs/win_ratio_simulation.md
+++ b/docs/win_ratio_simulation.md
@@ -1,0 +1,28 @@
+# Win-Ratio Simulation
+
+This module runs Monte Carlo simulations to estimate the statistical power of a
+win-ratio test for a composite endpoint. The win-ratio compares outcomes between
+a treatment and a control group when several ordered outcomes are of interest.
+
+## How it Works
+
+1. **Data Generation** – Binary outcomes for treatment and control groups are
+   generated with user-specified probabilities.
+2. **Pairwise Comparison** – Every treatment subject is compared with every
+   control subject hierarchically across outcomes; the first difference decides
+the winner.
+3. **Win-Ratio Calculation** – Total wins and losses form a win ratio.
+4. **Statistical Analysis** – Confidence intervals and p-values are computed on
+   the log scale.
+5. **Power Calculation** – Repeating the simulation many times yields the
+   proportion of significant results, i.e. the power.
+
+## Running the Simulation
+
+```bash
+python -m clintrials.winratio.main
+```
+
+Command-line options allow the sample sizes, probabilities and number of
+simulations to be modified. The script reports the estimated power and the
+average 95% confidence interval for the win ratio.

--- a/tests/test_winratio.py
+++ b/tests/test_winratio.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+from clintrials.winratio import (
+    calculate_confidence_intervals,
+    calculate_p_value,
+    calculate_win_ratio,
+    compare_subjects,
+    generate_data,
+    run_simulation,
+    simulate_comparisons,
+)
+
+
+def test_compare_subjects():
+    assert compare_subjects([1, 0, 0], [0, 0, 0]) == "win"
+    assert compare_subjects([0, 0, 0], [1, 0, 0]) == "loss"
+    assert compare_subjects([1, 0, 1], [1, 0, 1]) == "tie"
+
+
+def test_generate_data_shapes():
+    a, b = generate_data(5, 4, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5)
+    assert a.shape == (5, 3)
+    assert b.shape == (4, 3)
+
+
+def test_simulate_comparisons_counts():
+    treatment = np.array([[1, 0, 0]])
+    control = np.array([[0, 0, 0], [1, 0, 0]])
+    results = simulate_comparisons(treatment, control)
+    assert results == {"wins": 1, "losses": 0, "ties": 1}
+
+
+def test_statistics_helpers():
+    wr = calculate_win_ratio(20, 10)
+    assert wr == 2
+    ci = calculate_confidence_intervals(wr, 20, 10)
+    assert len(ci) == 2
+    p_val = calculate_p_value(wr, 20, 10)
+    assert 0 <= p_val <= 1
+
+
+def test_run_simulation_executes():
+    np.random.seed(0)
+    power, ci = run_simulation(5, 5, 10, 0.6, 0.4, 0.6, 0.4, 0.6, 0.4)
+    assert 0 <= power <= 1
+    assert len(ci) == 2


### PR DESCRIPTION
## Summary
- add `winratio` package with data generation, pairwise comparison, stats helpers and CLI
- document win-ratio power simulation and mention in project README
- test win-ratio functionality

## Testing
- `pre-commit run --files clintrials/winratio/__init__.py clintrials/winratio/compare.py clintrials/winratio/data_generation.py clintrials/winratio/simulate.py clintrials/winratio/statistics.py clintrials/winratio/main.py docs/win_ratio_simulation.md tests/test_winratio.py README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a47e3ed9d0832c92d29a78560b20c4