### PR TITLE
Add setup script for Poetry environment

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Setup script for the clintrials project.
+# Installs Poetry if necessary, installs dependencies,
+# and configures pre-commit hooks.
+
+set -euo pipefail
+
+if ! command -v poetry >/dev/null 2>&1; then
+  echo "Poetry not found. Installing..."
+  pip install --user poetry
+fi
+
+poetry install
+poetry run pre-commit install
+
+echo "Setup complete. Activate the environment with 'poetry shell'."


### PR DESCRIPTION
## Summary
- add setup script that installs Poetry if missing
- run project dependency installation and setup pre-commit hooks

## Testing
- `pre-commit run --files setup.sh`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a481c9cd88832c917601e40d67886e