### PR TITLE
docs: include missing tutorials in toctree

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,9 @@ Welcome to **clintrials**, a Python library providing clinical trial designs and
 
 installation
 user_guide/tutorials
+tutorials/matchpoint/README.md
 how_to/recipes
+win_ratio_simulation
 reference/index
 contributing
 changelog


### PR DESCRIPTION
## Summary
- add Matchpoint tutorial README to Sphinx toctree
- include win-ratio simulation page in main docs toctree

## Testing
- `pre-commit run --files docs/index.md`
- `sphinx-build -nW --keep-going -b html docs docs/_build/html`


------
https://chatgpt.com/codex/tasks/task_e_68a48c2a917c832caf4876ffb7beeca4