### PR TITLE
Fix pre-commit installation when hooks path is customized

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ furo = {version = "^2024.1.29", optional = true}
 [tool.poetry.scripts]
 dashboard = "clintrials.dashboard.main:main"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^8.2.0"
 pytest-cov = "^4.1.0"
 black = "^25.1.0"

--- a/setup.sh
+++ b/setup.sh
@@ -13,6 +13,10 @@ fi
 echo "Installing project dependencies with Poetry..."
 poetry install
 
+echo "Ensuring default git hooks path..."
+git config --global --unset-all core.hooksPath 2>/dev/null || true
+git config --unset-all core.hooksPath 2>/dev/null || true
+
 echo "Installing pre-commit hooks..."
 poetry run pre-commit install
 


### PR DESCRIPTION
## Summary
- ensure setup script resets git hooks path before installing pre-commit
- move dev dependencies to `[tool.poetry.group.dev.dependencies]` to remove deprecation warning

## Testing
- `poetry run pre-commit run --files pyproject.toml setup.sh`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a48c791910832cb939d00e9055117b